### PR TITLE
Book Like Formating

### DIFF
--- a/tesisTemplate.tex
+++ b/tesisTemplate.tex
@@ -5,7 +5,7 @@
 
 % twoside parameter
 % \documentclass[12pt,twoside, a4paper]{report}
-\documentclass[12pt,a4paper]{report}
+\documentclass[12pt,a4paper,twoside]{report}
 
 % Add catolica IMT package
 \usepackage{packages/ucbimt}


### PR DESCRIPTION
Added two side argument to document class in tesisTemplate.tex in order to mimic the layout of a physical book, where the spacing on the left and right sides of the page alternates depending on whether its an odd or even page.