### PR TITLE
fancypagestyle added to move the page numbers to the right

### DIFF
--- a/preambles/imt_preamble.tex
+++ b/preambles/imt_preamble.tex
@@ -111,3 +111,10 @@
 	labelfont=bf,
 	labelsep=dot,
 }
+
+\fancypagestyle{plain}{
+	\fancyhf{} % clear all header and footer fields
+	\fancyfoot[R]{\thepage} % except the right
+	\renewcommand{\headrulewidth}{0pt}
+	\renewcommand{\footrulewidth}{0pt}
+	}


### PR DESCRIPTION
In preamble fancypagestyle added to move the page numbers to the right.
According to the original word template given, the pages numbers must be in the right side of the page in line with the paragraphs right border.